### PR TITLE
fix missing historic wallet_balance issue

### DIFF
--- a/lib/portfolio_monitor/portfolio.ex
+++ b/lib/portfolio_monitor/portfolio.ex
@@ -155,14 +155,12 @@ defmodule PortfolioMonitor.Portfolio do
 
   defp oldest_historical_datum_within_days(diff) do
     {:ok, target_datetime} =
-      Date.utc_today()
-      |> Date.add(-diff)
-      |> NaiveDateTime.new(Time.utc_now())
+      Date.utc_today() |> Date.add(-diff) |> NaiveDateTime.new(Time.utc_now())
 
     from h in HistoricalDatum,
       where: h.inserted_at >= ^target_datetime,
       order_by: h.inserted_at,
-      limit: 1
+      distinct: h.bitmex_acc_id
   end
 
   def list_bitmex_accs do


### PR DESCRIPTION
limit 1 is causing only the most recently updated wallet balance to
appear, if the bitmex_acc_id doesn't match, it will become nil

closes #59 